### PR TITLE
Ignore array-valued elements in the term detail API response.

### DIFF
--- a/R/pk_terms.R
+++ b/R/pk_terms.R
@@ -73,7 +73,7 @@ pk_details <- function(term, as, verbose=FALSE) {
 
   queryseq <- list(iri = iri)
   lst <- pk_GET("http://kb.phenoscape.org/api/term", queryseq)
-  dplyr::as_data_frame(lst)
+  dplyr::as_data_frame(Filter(function(x) !is.list(x), lst))
 }
 
 pk_taxon_url <- "http://kb.phenoscape.org/api/taxon"


### PR DESCRIPTION
This fixes #6 and #8. The cost is that we lose the 'relationships' values from the response, but keeping them requires changing the returned value from a `data.frame` to a list, which is not going to be backwards compatible.