### PR TITLE
Tests values from Ontotrace API call for S4 class, not for producing output

### DIFF
--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -77,8 +77,8 @@ test_that("Test OnToTrace", {
   single_nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin")
   multi_nex <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus"), entity = c("fin spine", "pelvic splint"))
 
-  expect_output(class(single_nex), 'nexml')
-  expect_output(class(multi_nex), 'nexml')
+  expect_s4_class(single_nex, 'nexml')
+  expect_s4_class(multi_nex, 'nexml')
 
   err1 <- function() pk_get_ontotrace_xml(taxon = "Ictalurus TT", entity = "fin", relation = "other relation")
 


### PR DESCRIPTION
This fixes #7. While originally `class(nexml_object)` might have produced some output, this is not the case anymore, so we just check that indeed the value is an object of the correct S4 class, namely 'nexml'.