### PR TITLE
Fixes CircleCI R3 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,11 @@ steps: &steps
           - cache-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}
     - checkout
     - run:
+        name: Update openssl to avoid SSL errors after installing curl R module for R 3
+        command: apt-get update && apt-get install -y libcurl4-openssl-dev
+    - run:
         name: Install package dependencies
-        command: R -e "devtools::install_deps(dep = TRUE)"
+        command: R -e "devtools::install_deps(dep = TRUE, repos = 'https://cloud.r-project.org')"
     - run:
         name: Build package
         command: R CMD build .


### PR DESCRIPTION
Replaces MRAN with CRAN cloud mirror since MRAN is now defunct. To fix SSL errors after installing dependencies
libcurl4-openssl-dev is installed.

Fixes #278